### PR TITLE
changed commit behavior: won't commit if no change

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -32,7 +32,7 @@ then
 
 	# Commit changes.
 	msg="rebuilding site $(date)"
-	git commit -m "$msg"
+	git diff-index --quiet HEAD || git commit -m "$msg"
 
 	git push origin master
 else


### PR DESCRIPTION
This should prevent GitHub Actions exiting with code 1 when there's nothing to commit.