### PR TITLE
Increase the number of days to look back when generating community config

### DIFF
--- a/update-community.py
+++ b/update-community.py
@@ -8,7 +8,7 @@ FILE_NAME = '_data/community.yml'
 PROJECT_NAME = 'COVID-19 Forecasts'
 DATE_FORMAT = "%A, %d %B %Y"
 ZOLTAR_HOST_URL = 'https://zoltardata.com'
-DAYS_OLD = 14
+DAYS_OLD = 16
 
 
 def get_public_url(url):


### PR DESCRIPTION
This changeset works around an issue with ad-hoc deployments that occur past the 14 day zeroday lookback, thus generating an empty _data/community.yml file (which in turn generates an empty page at https://covid19forecasthub.org/community/)

Not clear if this is the final answer, but changing the window from 14 days to 16 days at least temporarily will allow us to fix the community page.